### PR TITLE
ペインの移動を設定する

### DIFF
--- a/wezterm.lua
+++ b/wezterm.lua
@@ -79,6 +79,17 @@ config.keys = {
 		mods = "CMD",
 		action = wezterm.action.CloseCurrentPane({ confirm = true }),
 	},
+	-- アクティブなペインを移動
+	{
+		key = "]",
+		mods = "CMD",
+		action = wezterm.action.ActivatePaneDirection("Next"),
+	},
+	{
+		key = "[",
+		mods = "CMD",
+		action = wezterm.action.ActivatePaneDirection("Prev"),
+	},
 	-- Enter, cmdでtoggle full screen
 	{
 		key = "Enter",


### PR DESCRIPTION
iTermのペイン移動ショートカットキーが手に馴染んでいるので、同じ設定を追加します