### PR TITLE
macOSのfullscreen_modeを有効にする

### DIFF
--- a/wezterm.lua
+++ b/wezterm.lua
@@ -17,6 +17,7 @@ config.font_size = 18.0
 config.use_ime = true
 config.window_background_opacity = 0.85
 config.macos_window_background_blur = 20
+config.native_macos_fullscreen_mode = true
 
 -- Tab
 


### PR DESCRIPTION
フルスクリーンにしたときに、新たなウィンドウを開くようにします